### PR TITLE
Add VocabularyViewModel and VocabularyCell for word management

### DIFF
--- a/SwiftRun/SwiftRun/VocabularyCell.swift
+++ b/SwiftRun/SwiftRun/VocabularyCell.swift
@@ -1,0 +1,64 @@
+//
+//  VocabularyCell.swift
+//  SwiftRun
+//
+//  Created by 반성준 on 1/9/25.
+//
+
+
+import UIKit
+import SnapKit
+
+class VocabularyCell: UITableViewCell {
+    let nameLabel = UILabel()
+    let definitionLabel = UILabel()
+    let memorizeTag = UIButton()
+
+    var onMemorizeToggle: (() -> Void)?
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupUI() {
+        // Name Label
+        nameLabel.font = UIFont.boldSystemFont(ofSize: 16)
+        contentView.addSubview(nameLabel)
+
+        // Definition Label
+        definitionLabel.font = UIFont.systemFont(ofSize: 14)
+        definitionLabel.textColor = .darkGray
+        contentView.addSubview(definitionLabel)
+
+        // Memorize Tag
+        memorizeTag.titleLabel?.font = UIFont.systemFont(ofSize: 12)
+        memorizeTag.layer.cornerRadius = 8
+        memorizeTag.backgroundColor = .systemGray
+        memorizeTag.addTarget(self, action: #selector(toggleMemorize), for: .touchUpInside)
+        contentView.addSubview(memorizeTag)
+
+        // SnapKit Constraints
+        nameLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().offset(16)
+        }
+
+        definitionLabel.snp.makeConstraints { make in
+            make.top.equalTo(nameLabel.snp.bottom).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+
+        memorizeTag.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-16)
+            make.centerY.equalTo(nameLabel)
+        }
+    }
+
+    @objc private func toggleMemorize() {
+        onMemorizeToggle?()
+    }
+}

--- a/SwiftRun/SwiftRun/WordList/ViewModel/VocabularyViewModel.swift
+++ b/SwiftRun/SwiftRun/WordList/ViewModel/VocabularyViewModel.swift
@@ -1,0 +1,50 @@
+//
+//  VocabularyViewModel.swift
+//  SwiftRun
+//
+//  Created by 반성준 on 1/9/25.
+//
+
+
+import Foundation
+import RxSwift
+import RxCocoa
+
+class VocabularyViewModel {
+    // Outputs
+    let vocabularies: BehaviorRelay<[Vocabulary]> = BehaviorRelay(value: [])
+    let errorMessage: PublishRelay<String> = PublishRelay()
+
+    private let disposeBag = DisposeBag()
+
+    // Fetch vocabulary data
+    func fetchVocabulary() {
+        let url = URL(string: "https://iosvocabulary-default-rtdb.firebaseio.com/items/category1.json")!
+        NetworkManager.shared.fetch(url: url)
+            .subscribe(onSuccess: { [weak self] (data: [String: Vocabulary]) in
+                let vocabList = data.map { $0.value }
+                self?.vocabularies.accept(vocabList)
+            }, onFailure: { [weak self] error in
+                self?.errorMessage.accept("데이터를 가져오는 데 실패했습니다: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // Toggle memorize state
+    func toggleMemorizeState(at index: Int) {
+        var currentVocabularies = vocabularies.value
+        guard index < currentVocabularies.count else { return }
+        currentVocabularies[index].didMemorize.toggle()
+        vocabularies.accept(currentVocabularies)
+    }
+
+    // Helper methods
+    func numberOfVocabularies() -> Int {
+        return vocabularies.value.count
+    }
+
+    func vocabulary(at index: Int) -> Vocabulary? {
+        guard index < vocabularies.value.count else { return nil }
+        return vocabularies.value[index]
+    }
+}


### PR DESCRIPTION
### **1. VocabularyViewModel**

**작업사항:**
단어 데이터를 관리하고 네트워크에서 가져오는 로직을 구현.
RxSwift를 사용해 UI와 데이터의 실시간 바인딩 처리.

**주요내용:**
fetchVocabulary():
Firebase에서 단어 데이터를 가져와 vocabularies 상태로 저장.
네트워크 요청 성공 시 데이터를 파싱하고, 실패 시 에러를 전달.
toggleMemorizeState(at:):
단어의 암기 여부(didMemorize)를 토글.
데이터 상태가 변경되면 View가 자동으로 업데이트.
vocabularies:
BehaviorRelay를 사용해 단어 목록 상태를 관리.
UI가 상태 변화를 즉시 반영할 수 있도록 구현.

### **2. VocabularyCell**

**작업사항:**
단어 정보(이름, 정의)와 암기 상태를 표시하는 커스텀 셀을 구현.
SnapKit을 사용해 UI 요소 배치를 설정.

**주요내용:**
UI 구성:
nameLabel: 단어 이름을 Bold 텍스트로 표시.
definitionLabel: 단어 정의를 표시.
memorizeTag: 암기 상태를 나타내는 버튼.
Memorize Toggle:
버튼 클릭 시 onMemorizeToggle 콜백을 호출해 상태를 변경.