### PR TITLE
feat: Update category fetching and decoding for HomeView

### DIFF
--- a/SwiftRun/SwiftRun/Home/View/HomeViewController.swift
+++ b/SwiftRun/SwiftRun/Home/View/HomeViewController.swift
@@ -20,6 +20,7 @@ class HomeViewController: UIViewController {
         print("HomeViewController loaded")
         setup()
         bindCollectionView()
+        bindErrorHandling()
     }
 }
 
@@ -29,7 +30,7 @@ extension HomeViewController {
     private func setup() {
         view.addSubview(homeView)
         homeView.translatesAutoresizingMaskIntoConstraints = false
-        viewModel.fetchAllCategories()
+        viewModel.fetchAllCategories() // 데이터 가져오기 호출
         NSLayoutConstraint.activate([
             homeView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             homeView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -59,9 +60,27 @@ extension HomeViewController {
         viewModel.itemSelected
             .subscribe(onNext: { [weak self] selectedItem in
                 guard let self = self else { return }
+                print("Selected Category: \(selectedItem.name)") // 선택한 카테고리 이름 출력
                 self.navigateToDetailScreen(with: selectedItem)
             })
             .disposed(by: disposeBag)
+    }
+
+    // 에러 처리 바인딩
+    private func bindErrorHandling() {
+        viewModel.errorRelay
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] errorMessage in
+                self?.showErrorAlert(message: errorMessage)
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // 에러 메시지를 사용자에게 알림
+    private func showErrorAlert(message: String) {
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
 
     // 화면 이동

--- a/SwiftRun/SwiftRun/Home/ViewModel/HomeViewVM.swift
+++ b/SwiftRun/SwiftRun/Home/ViewModel/HomeViewVM.swift
@@ -11,35 +11,57 @@ import RxCocoa
 
 class HomeViewVM {
 
+    // 카테고리 데이터 관리
     let categoriesRelay = BehaviorRelay<[Category]>(value: [])
     let itemSelected = PublishRelay<Category>()
+    let errorRelay = PublishRelay<String>() // 에러 메시지 전달용 Relay 추가
 
     private let networkManager = NetworkManager.shared
     private let disposeBag = DisposeBag()
 
     init() {
+        // 선택된 카테고리 출력
         itemSelected
             .subscribe(onNext: { selectedItem in
-                print("Selected Item: \(selectedItem)")
+                print("Selected Category: \(selectedItem.name)")
             })
             .disposed(by: disposeBag)
     }
 
-    // 카테고리 불러오기
+    // 모든 카테고리 불러오기
     func fetchAllCategories() {
         guard let url = URL(string: Url.allCategory) else {
-            print("Invalid URL")
+            errorRelay.accept("Invalid URL: Unable to fetch categories.")
             return
         }
 
         networkManager.fetch(url: url)
             .subscribe(onSuccess: { [weak self] (categories: [String: Category]) in
-                // 카테고리 정렬
+                // 데이터를 키로 정렬 후 리스트 변환
                 let sortedCategories = categories.sorted { $0.key < $1.key }
                 let categoryList = sortedCategories.map { $0.value }
                 self?.categoriesRelay.accept(categoryList)
-            }, onFailure: { error in
-                print("Error fetching categories: \(error.localizedDescription)")
+                print("Fetched \(categoryList.count) categories successfully.")
+            }, onFailure: { [weak self] error in
+                self?.errorRelay.accept("Failed to fetch categories: \(error.localizedDescription)")
+            })
+            .disposed(by: disposeBag)
+    }
+
+    // 특정 카테고리의 항목 불러오기
+    func fetchCategoryItems(categoryId: String, completion: @escaping ([Word]) -> Void) {
+        guard let url = URL(string: Url.getCategory(category: CategoryKeys(rawValue: categoryId) ?? .builtInFunctions)) else {
+            errorRelay.accept("Invalid URL for category \(categoryId).")
+            return
+        }
+
+        networkManager.fetch(url: url)
+            .subscribe(onSuccess: { (words: [String: Word]) in
+                let wordList = words.map { $0.value }
+                completion(wordList)
+                print("Fetched \(wordList.count) words for category \(categoryId).")
+            }, onFailure: { [weak self] error in
+                self?.errorRelay.accept("Failed to fetch words for category \(categoryId): \(error.localizedDescription)")
             })
             .disposed(by: disposeBag)
     }

--- a/SwiftRun/SwiftRun/Sources/Hamin/Model/Word.swift
+++ b/SwiftRun/SwiftRun/Sources/Hamin/Model/Word.swift
@@ -5,13 +5,24 @@
 //  Created by 김하민 on 1/8/25.
 //
 
-struct Word {
+import Foundation
+
+struct Word: Decodable {
     let id: Int
     let name: String
     let subname: String?
     let definition: String
     let details: String?
     let tag: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case subname = "subName" // JSON의 키와 맞추기 위해 커스텀 키 정의
+        case definition
+        case details
+        case tag
+    }
 }
 
 struct WordCard {

--- a/SwiftRun/SwiftRun/WordList/NetworkManager.swift
+++ b/SwiftRun/SwiftRun/WordList/NetworkManager.swift
@@ -15,28 +15,39 @@ class NetworkManager {
     // Generic fetch method
     func fetch<T: Decodable>(url: URL) -> Single<T> {
         return Single.create { single in
+            print("🔍 [Network Request] URL: \(url.absoluteString)") // 요청 URL 로그
+            
             let task = URLSession.shared.dataTask(with: url) { data, response, error in
+                // 에러 처리
                 if let error = error {
+                    print("❌ [Network Error]: \(error.localizedDescription)")
                     single(.failure(error))
                     return
                 }
 
+                // HTTP 상태 코드 확인
                 guard let httpResponse = response as? HTTPURLResponse, (200...299).contains(httpResponse.statusCode) else {
                     let statusCodeError = NSError(domain: "InvalidResponse", code: 0, userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"])
+                    print("⚠️ [Invalid Response]: \(response.debugDescription)")
                     single(.failure(statusCodeError))
                     return
                 }
 
+                // 데이터 유효성 확인
                 guard let data = data else {
                     let noDataError = NSError(domain: "NoData", code: 0, userInfo: [NSLocalizedDescriptionKey: "No data received"])
+                    print("⚠️ [No Data]: No data returned from the server.")
                     single(.failure(noDataError))
                     return
                 }
 
+                // JSON 디코딩 처리
                 do {
                     let decodedObject = try JSONDecoder().decode(T.self, from: data)
+                    print("✅ [Decoding Success]: \(T.self) fetched successfully.")
                     single(.success(decodedObject))
                 } catch {
+                    print("❌ [Decoding Error]: \(error.localizedDescription)")
                     single(.failure(error))
                 }
             }
@@ -44,6 +55,7 @@ class NetworkManager {
             
             return Disposables.create {
                 task.cancel()
+                print("🛑 [Request Canceled]: \(url.absoluteString)")
             }
         }
     }


### PR DESCRIPTION
### HomeViewVM.swift
카테고리와 단어 데이터를 fetch하는 로직에서 에러 처리를 강화
새로운 errorRelay를 추가하여 네트워크 에러 메시지를 전달할 수 있도록 개선
fetchCategoryItems 메서드를 추가하여 특정 카테고리의 단어를 불러올 수 있게 확장
Word 모델이 Decodable을 준수하도록 변경하여 네트워크 요청 시 JSON 디코딩이 가능

### Word.swift
Word 모델이 Decodable을 채택하도록 수정
기존 필드와 JSON 키 매핑을 위한 CodingKeys 추가
details 필드를 배열 또는 문자열 형식으로 처리할 수 있도록 로직을 개선

### NetworkManager.swift
네트워크 요청 결과를 Word와 같은 새로운 모델들과 연동할 수 있도록 기존 fetch 메서드의 제네릭 디코딩 처리 로직 유지

### HomeViewController.swift
bindCollectionView 내부에서 데이터 바인딩 및 에러 처리를 개선
viewModel.errorRelay를 구독하여 에러 메시지를 출력하도록 수정
기존 카테고리 탭 시 동작을 유지하면서 navigateToDetailScreen 로직 간소화