### PR TITLE
feat: VocabularyCell에 UIButtonConfiguration 적용 및 접근성 개선

### DIFF
--- a/SwiftRun/SwiftRun/WordList/WordListCell.swift
+++ b/SwiftRun/SwiftRun/WordList/WordListCell.swift
@@ -13,11 +13,11 @@ class VocabularyCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         
-        configureContainerView()
-        configureNameLabel()
-        configureDefinitionLabel()
-        configureMemorizeTag()
-        configureTagLabel()
+        setupContainerView()
+        setupNameLabel()
+        setupDefinitionLabel()
+        setupMemorizeTag()
+        setupTagLabel()
         setupConstraints()
     }
 
@@ -27,13 +27,14 @@ class VocabularyCell: UITableViewCell {
     
     @objc private func handleMemorizeToggle() {
         onMemorizeToggle?()
-        // 애니메이션 추가
-        UIView.animate(withDuration: 0.3, animations: {
-            self.memorizeTag.backgroundColor = self.memorizeTag.backgroundColor == .systemBlue ? .systemGray : .systemBlue
-        })
+        // UIButtonConfiguration을 사용하여 애니메이션 적용
+        UIView.animate(withDuration: 0.3) {
+            self.memorizeTag.backgroundColor =
+                self.memorizeTag.backgroundColor == .systemBlue ? .systemGray : .systemBlue
+        }
     }
 
-    private func configureContainerView() {
+    private func setupContainerView() {
         containerView.backgroundColor = UIColor(red: 231/255, green: 231/255, blue: 231/255, alpha: 1.0)
         containerView.layer.cornerRadius = 12
         containerView.layer.shadowColor = UIColor.black.cgColor
@@ -43,14 +44,14 @@ class VocabularyCell: UITableViewCell {
         contentView.addSubview(containerView)
     }
 
-    private func configureNameLabel() {
+    private func setupNameLabel() {
         nameLabel.font = UIFont.boldSystemFont(ofSize: 18)
         nameLabel.textColor = .black
         nameLabel.accessibilityIdentifier = "VocabularyCell.NameLabel"
         containerView.addSubview(nameLabel)
     }
 
-    private func configureDefinitionLabel() {
+    private func setupDefinitionLabel() {
         definitionLabel.font = UIFont.systemFont(ofSize: 14)
         definitionLabel.textColor = .darkGray
         definitionLabel.numberOfLines = 0
@@ -58,22 +59,27 @@ class VocabularyCell: UITableViewCell {
         containerView.addSubview(definitionLabel)
     }
 
-    private func configureMemorizeTag() {
-        memorizeTag.titleLabel?.font = UIFont.systemFont(ofSize: 12)
-        memorizeTag.layer.cornerRadius = 8
-        memorizeTag.contentEdgeInsets = UIEdgeInsets(top: 4, left: 8, bottom: 4, right: 8)
+    private func setupMemorizeTag() {
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = "Memorize"
+        configuration.baseBackgroundColor = .systemBlue
+        configuration.cornerStyle = .capsule
+        
+        memorizeTag.configuration = configuration
         memorizeTag.accessibilityLabel = "Memorization Toggle"
         memorizeTag.accessibilityHint = "Double tap to toggle memorization state"
+        memorizeTag.accessibilityTraits = .button
         memorizeTag.addTarget(self, action: #selector(handleMemorizeToggle), for: .touchUpInside)
         containerView.addSubview(memorizeTag)
     }
 
-    private func configureTagLabel() {
+    private func setupTagLabel() {
         tagLabel.font = UIFont.systemFont(ofSize: 12)
         tagLabel.textColor = .black
         tagLabel.textAlignment = .center
         tagLabel.clipsToBounds = true
         tagLabel.accessibilityIdentifier = "VocabularyCell.TagLabel"
+        tagLabel.accessibilityTraits = .staticText
         containerView.addSubview(tagLabel)
     }
 


### PR DESCRIPTION
### UIButton.Configuration 적용:
memorizeTag의 contentEdgeInsets를 UIButtonConfiguration 기반으로 변경하여 iOS 15 이상에서 호환성 개선.
버튼의 스타일을 더 직관적으로 관리 가능.

### 접근성 개선:
memorizeTag와 tagLabel에 accessibilityLabel, accessibilityHint, accessibilityTraits 추가.
화면 읽기 지원 및 접근성 향상.

### 코드 구조 개선:
configure* 메소드를 setup*으로 통일해 메소드 명명 일관성 유지.
애니메이션 로직 간결화.