### PR TITLE
update:Refactor WordBookCollectionCell

### DIFF
--- a/SwiftRun/SwiftRun/Home/View/WordBookCollectionCell.swift
+++ b/SwiftRun/SwiftRun/Home/View/WordBookCollectionCell.swift
@@ -10,39 +10,48 @@ import SnapKit
 
 class WordBookCollectionCell: UICollectionViewCell {
     
-    static let identifier = "wordBookCollectionCell"
+    static let identifier = String(describing: WordBookCollectionCell.self)
     
-    let wordBookTitle: UILabel = {
+    private let wordBookTitle: UILabel = {
         let label = UILabel()
         label.textAlignment = .center
         label.textColor = UIColor(named: "SRBlue400")
         label.layer.borderWidth = 2
         label.layer.cornerRadius = 10
+        label.layer.masksToBounds = true
         label.layer.borderColor = UIColor(named: "SRBlue400")?.cgColor
         label.numberOfLines = 2
+        label.font = UIFont.preferredFont(forTextStyle: .headline)
+        label.adjustsFontForContentSizeCategory = true
         return label
     }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        addSubview(wordBookTitle)
-        
-        wordBookTitle.snp.makeConstraints { make in
-            make.center.equalToSuperview()
-            make.size.equalToSuperview()
-        }
+        configureUI()
+        setupConstraints()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
+    private func configureUI() {
+        addSubview(wordBookTitle)
+    }
+    
+    private func setupConstraints() {
+        wordBookTitle.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(8)
+        }
+    }
+    
     func configure(with item: Category) {
-        wordBookTitle.text = item.name
+        wordBookTitle.text = item.name.isEmpty ? "Unnamed Category" : item.name
     }
 }
 
 @available(iOS 17.0, *)
-#Preview("HomeViewController") {
-    HomeViewController()
+#Preview("WordBookCollectionCell") {
+    WordBookCollectionCell()
 }


### PR DESCRIPTION
### 코드 리팩토링:
identifier를 클래스 이름으로 동적으로 설정(String(describing:))하여 재사용성을 높임
wordBookTitle에 adjustsFontForContentSizeCategory 추가하여 다이나믹 타입을 지원
wordBookTitle의 font를 UIFont.preferredFont(forTextStyle:)로 변경하여 접근성을 강화
wordBookTitle 텍스트가 비어있을 경우 기본값 "Unnamed Category"를 설정하도록 configure 메서드 수정

### UI 개선:
wordBookTitle의 layer.masksToBounds를 true로 설정하여 둥근 모서리 적용 시 불필요한 렌더링 문제 해결
wordBookTitle의 외부 여백을 inset(8)로 설정해 더 균형 있는 레이아웃 